### PR TITLE
Change LocalParameterization to ceres::Manifold

### DIFF
--- a/src/estimator.h
+++ b/src/estimator.h
@@ -56,7 +56,7 @@ protected:
     std::map<size_t, Eigen::Matrix3d> Cov_a_arr, Cov_w_arr, Cov_ab_arr, Cov_wb_arr;
 
     // Define local parameterization to optimize quaternion on its own manifold (i.e. q \in R^4 where \norm(q) = 1)
-    ceres::LocalParameterization* quat_loc_parameterization = new ceres::EigenQuaternionParameterization;
+    ceres::Manifold* quat_loc_parameterization = new ceres::EigenQuaternionManifold;
 
     // ceres::Problem object
     ceres::Problem problem;

--- a/src/run_record.cpp
+++ b/src/run_record.cpp
@@ -110,7 +110,7 @@ int main(int argc, char** argv)
     // export estimated pose to file
     std::string export_filename = params.filepath_csv + params.filename_csv;
     std::cout << " -- EXPORT RESULTS AT " << export_filename << "..." << std::endl;
-    export_pose(export_filename, imu_pose_estimated.at(1), gyr_mis_estimated, estimator.get_result(), estimator.print_timer());
+    export_pose(export_filename, imu_pose_estimated.at(1), gyr_mis_estimated, true, estimator.print_timer());
     
     // erase A0 pose information
     imu_pose_initial.erase(0);


### PR DESCRIPTION
A newer ceres version using `ceres::Manifold` instead of `ceres::LocalParameterization`, and `EigenQuaternionManifold` for `EigenQuaternionParameterization`.
Also, a confusing `get_result()` is removed, which I think won't have any effects.
